### PR TITLE
feat: add simple portfolio tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Monitor de Portfolio
+
+Aplicación web sencilla para llevar el control de compras de acciones, CEDEARs y criptomonedas. Permite:
+
+- Registrar compras con ticker, cantidad, precio y fecha.
+- Calcular precio promedio de compra por ticker.
+- Obtener cotizaciones actuales desde [Yahoo Finance](https://finance.yahoo.com).
+- Ver desempeño de cada activo y del portfolio total.
+- Exportar e importar datos almacenados en `localStorage`.
+
+Para usarla solo es necesario abrir `index.html` en un navegador moderno con acceso a internet.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,164 @@
+const STORAGE_KEY = 'transactions';
+let transactions = [];
+
+function loadTransactions() {
+    const data = localStorage.getItem(STORAGE_KEY);
+    if (data) {
+        try {
+            transactions = JSON.parse(data);
+        } catch (e) {
+            console.error('Error al parsear datos', e);
+            transactions = [];
+        }
+    }
+}
+
+function saveTransactions() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(transactions));
+}
+
+function addTransaction(ticker, quantity, price, date) {
+    transactions.push({ ticker, quantity: Number(quantity), price: Number(price), date });
+    saveTransactions();
+    render();
+}
+
+function groupedByTicker() {
+    const groups = {};
+    for (const tx of transactions) {
+        if (!groups[tx.ticker]) groups[tx.ticker] = [];
+        groups[tx.ticker].push(tx);
+    }
+    return groups;
+}
+
+async function fetchPrices(tickers) {
+    const url = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${tickers.join(',')}`;
+    const res = await fetch(url);
+    const json = await res.json();
+    const prices = {};
+    for (const q of json.quoteResponse.result) {
+        prices[q.symbol] = q.regularMarketPrice;
+    }
+    return prices;
+}
+
+function renderHistory() {
+    const tbody = document.querySelector('#history-table tbody');
+    tbody.innerHTML = '';
+    for (const tx of transactions) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${tx.ticker}</td><td>${tx.quantity}</td><td>${tx.price}</td><td>${tx.date || ''}</td>`;
+        tbody.appendChild(tr);
+    }
+}
+
+async function renderPortfolio() {
+    const groups = groupedByTicker();
+    const tickers = Object.keys(groups);
+    const prices = tickers.length ? await fetchPrices(tickers) : {};
+    const tbody = document.querySelector('#portfolio-table tbody');
+    tbody.innerHTML = '';
+
+    let totalInvested = 0;
+    let currentValue = 0;
+
+    for (const ticker of tickers) {
+        const txs = groups[ticker];
+        let qty = 0;
+        let invested = 0;
+        for (const tx of txs) {
+            qty += tx.quantity;
+            invested += tx.quantity * tx.price;
+        }
+        const avg = invested / qty;
+        const price = prices[ticker] || 0;
+        const value = price * qty;
+        const pl = value - invested;
+        const change = invested ? (pl / invested) * 100 : 0;
+
+        totalInvested += invested;
+        currentValue += value;
+
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${ticker}</td>
+            <td>${qty.toFixed(4)}</td>
+            <td>${avg.toFixed(2)}</td>
+            <td>${price.toFixed(2)}</td>
+            <td>${value.toFixed(2)}</td>
+            <td class="${pl >= 0 ? 'gain' : 'loss'}">${pl.toFixed(2)}</td>
+            <td class="${pl >= 0 ? 'gain' : 'loss'}">${change.toFixed(2)}%</td>
+        `;
+        tbody.appendChild(tr);
+    }
+
+    const totalPL = currentValue - totalInvested;
+    const totalReturn = totalInvested ? (totalPL / totalInvested) * 100 : 0;
+
+    document.getElementById('total-invested').textContent = totalInvested.toFixed(2);
+    document.getElementById('current-value').textContent = currentValue.toFixed(2);
+    document.getElementById('total-pl').textContent = totalPL.toFixed(2);
+    document.getElementById('total-return').textContent = totalReturn.toFixed(2) + '%';
+}
+
+function exportData() {
+    const blob = new Blob([JSON.stringify(transactions, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'portfolio.json';
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+function importData(file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+        try {
+            const data = JSON.parse(reader.result);
+            if (Array.isArray(data)) {
+                transactions = data;
+                saveTransactions();
+                render();
+            }
+        } catch (e) {
+            console.error('Archivo inválido', e);
+        }
+    };
+    reader.readAsText(file);
+}
+
+function render() {
+    renderHistory();
+    renderPortfolio();
+}
+
+// Event listeners
+
+const form = document.getElementById('transaction-form');
+form.addEventListener('submit', e => {
+    e.preventDefault();
+    const ticker = document.getElementById('ticker').value.trim().toUpperCase();
+    const qty = document.getElementById('cantidad').value;
+    const price = document.getElementById('precio').value;
+    const date = document.getElementById('fecha').value;
+    addTransaction(ticker, qty, price, date);
+    form.reset();
+});
+
+document.getElementById('exportar').addEventListener('click', exportData);
+
+const importBtn = document.getElementById('importar-btn');
+const importInput = document.getElementById('importar');
+importBtn.addEventListener('click', () => importInput.click());
+importInput.addEventListener('change', e => {
+    if (e.target.files.length) {
+        importData(e.target.files[0]);
+    }
+});
+
+window.addEventListener('load', () => {
+    loadTransactions();
+    render();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfolio Tracker</title>
+    <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+    <header>
+        <h1>Monitor de Portfolio</h1>
+    </header>
+
+    <main>
+        <section id="add-transaction">
+            <h2>Agregar Compra</h2>
+            <form id="transaction-form">
+                <input type="text" id="ticker" placeholder="Ticker (ej. AAPL, BTC-USD)" required />
+                <input type="number" step="any" id="cantidad" placeholder="Cantidad" required />
+                <input type="number" step="any" id="precio" placeholder="Precio" required />
+                <input type="date" id="fecha" />
+                <button type="submit">Agregar</button>
+            </form>
+        </section>
+
+        <section id="resumen">
+            <h2>Resumen</h2>
+            <div id="portfolio-metrics">
+                <div><strong>Inversión Total:</strong> <span id="total-invested">0</span></div>
+                <div><strong>Valor Actual:</strong> <span id="current-value">0</span></div>
+                <div><strong>Ganancia/Pérdida:</strong> <span id="total-pl">0</span></div>
+                <div><strong>Rentabilidad:</strong> <span id="total-return">0%</span></div>
+            </div>
+            <table id="portfolio-table">
+                <thead>
+                    <tr>
+                        <th>Ticker</th>
+                        <th>Cantidad</th>
+                        <th>Precio Promedio</th>
+                        <th>Precio Actual</th>
+                        <th>Valor</th>
+                        <th>Ganancia/Pérdida</th>
+                        <th>Var %</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </section>
+
+        <section id="historial">
+            <h2>Historial de Compras</h2>
+            <table id="history-table">
+                <thead>
+                    <tr>
+                        <th>Ticker</th>
+                        <th>Cantidad</th>
+                        <th>Precio</th>
+                        <th>Fecha</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </section>
+
+        <section id="acciones">
+            <button id="exportar">Exportar Datos</button>
+            <input type="file" id="importar" style="display:none" />
+            <button id="importar-btn">Importar Datos</button>
+        </section>
+    </main>
+
+    <footer>
+        <p>Los precios se obtienen de Yahoo Finance.</p>
+    </footer>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,72 @@
+:root {
+    --bg: #121212;
+    --text: #e0e0e0;
+    --accent: #1e88e5;
+    --card-bg: #1e1e1e;
+    --gain: #4caf50;
+    --loss: #e53935;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+body {
+    background-color: var(--bg);
+    color: var(--text);
+    margin: 0;
+}
+
+header, footer {
+    text-align: center;
+    padding: 1rem;
+    background-color: var(--card-bg);
+}
+
+main {
+    padding: 1rem;
+    display: grid;
+    gap: 2rem;
+}
+
+section {
+    background-color: var(--card-bg);
+    padding: 1rem;
+    border-radius: 8px;
+}
+
+input, button {
+    margin: 0.5rem;
+    padding: 0.5rem;
+    border-radius: 4px;
+    border: none;
+}
+
+button {
+    background-color: var(--accent);
+    color: var(--text);
+    cursor: pointer;
+}
+
+button:hover {
+    opacity: 0.9;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    padding: 0.5rem;
+    text-align: center;
+}
+
+tbody tr:nth-child(odd) {
+    background-color: #2a2a2a;
+}
+
+.gain {
+    color: var(--gain);
+}
+
+.loss {
+    color: var(--loss);
+}


### PR DESCRIPTION
## Summary
- build dark-themed web app to track equity and crypto purchases
- calculate average cost, fetch current prices via Yahoo Finance, and show performance metrics
- store transactions in localStorage with import/export functionality

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a362f03c083298b996720a589fd81